### PR TITLE
Initialize AlviaOrange project

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,26 @@
+name: Python package
+
+on:
+  push:
+    branches: ["main", "work"]
+  pull_request:
+    branches: ["main", "work"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install .
+        pip install pytest
+    - name: Run tests
+      run: |
+        pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,88 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Virtualenv
+.venv/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pyenv
+.python-version
+
+# Editor directories and files
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+
+# Other
+*.log
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 AlviaOrange
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# AlviaOrange
+
+AlviaOrange is an open-source collection of wildfire analytics and simulation tools.
+The goal is to make it easy for data scientists to experiment with algorithms and
+for developers to integrate them into larger systems such as the AlviaPlatform.
+
+## Setup
+
+```bash
+# Clone the repository
+git clone <repo-url>
+cd AlviaOrange
+
+# Create a virtual environment (optional but recommended)
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+# Run tests
+pytest
+```
+
+## Running the example notebook
+
+Install the optional Jupyter dependencies and start the notebook server:
+
+```bash
+pip install jupyter
+jupyter notebook notebooks/example.ipynb
+```
+
+## Node.js/TypeScript integration
+
+Developers can interface with the Python tools using a CLI script or by exposing an
+HTTP endpoint with frameworks like Flask or FastAPI. The CLI approach allows calling
+Python scripts from Node.js using `child_process`. For more advanced use cases,
+consider running a lightweight HTTP server to expose endpoints for hotspot
+retrieval or simulation.
+
+## Using the CLI
+
+Invoke the command line interface to print hotspots:
+
+```bash
+python -m alviaorange.cli --region Canada
+```
+
+## Starting the HTTP server
+
+An HTTP endpoint can be started with:
+
+```bash
+python scripts/run_server.py
+```
+
+This exposes `/hotspots?region=Canada` which returns a JSON list of hotspots.
+
+## Packaging and Distribution
+
+The project uses a `pyproject.toml` file for packaging. Once stable, the package can
+be published to PyPI so other projects (like AlviaPlatform) can install it as a
+standard dependency.
+
+To build and install locally:
+
+```bash
+pip install build
+python -m build
+pip install dist/alviaorange-*.whl
+```
+
+## Contributing Notebooks or Algorithms
+
+Place new notebooks in the `notebooks/` directory and keep algorithm modules inside
+`alviaorange/`. Ensure that any new functionality includes corresponding tests in
+`tests/`. Follow PEP 8 style and include type hints where practical.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/alviaorange/__init__.py
+++ b/alviaorange/__init__.py
@@ -1,0 +1,5 @@
+"""Core package for AlviaOrange wildfire analytics."""
+
+from .hotspots import fetch_hotspots
+
+__all__ = ["fetch_hotspots"]

--- a/alviaorange/cli.py
+++ b/alviaorange/cli.py
@@ -1,0 +1,25 @@
+"""Command line interface for AlviaOrange."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterable
+
+from .hotspots import fetch_hotspots
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Fetch wildfire hotspots")
+    parser.add_argument(
+        "--region",
+        default="Canada",
+        help="Region for which to fetch hotspots (default: Canada)",
+    )
+    args = parser.parse_args(argv)
+    hotspots = fetch_hotspots(args.region)
+    for hotspot in hotspots:
+        print(hotspot)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/alviaorange/hotspots.py
+++ b/alviaorange/hotspots.py
@@ -1,0 +1,17 @@
+"""Example hotspot retrieval module."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+def fetch_hotspots(region: str = "Canada") -> List[str]:
+    """Return a list of hotspot identifiers for a given region.
+
+    This is a placeholder implementation that returns sample data.
+    """
+    sample_data = {
+        "Canada": ["AB-001", "BC-123"],
+        "USA": ["CA-999", "OR-456"],
+    }
+    return sample_data.get(region, [])

--- a/alviaorange/regions/__init__.py
+++ b/alviaorange/regions/__init__.py
@@ -1,0 +1,5 @@
+"""Regional wildfire algorithms."""
+
+from . import canada, usa
+
+__all__ = ["canada", "usa"]

--- a/alviaorange/regions/canada.py
+++ b/alviaorange/regions/canada.py
@@ -1,0 +1,10 @@
+"""Placeholder algorithms specific to Canada."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+def fetch_region_hotspots() -> List[str]:
+    """Return sample hotspot identifiers for Canada."""
+    return ["AB-001", "BC-123"]

--- a/alviaorange/regions/usa.py
+++ b/alviaorange/regions/usa.py
@@ -1,0 +1,10 @@
+"""Placeholder algorithms specific to the USA."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+def fetch_region_hotspots() -> List[str]:
+    """Return sample hotspot identifiers for the USA."""
+    return ["CA-999", "OR-456"]

--- a/alviaorange/server.py
+++ b/alviaorange/server.py
@@ -1,0 +1,15 @@
+"""Minimal HTTP server exposing hotspot retrieval."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .hotspots import fetch_hotspots
+
+app = FastAPI()
+
+
+@app.get("/hotspots")
+def get_hotspots(region: str = "Canada") -> list[str]:
+    """Return hotspots for the specified region."""
+    return fetch_hotspots(region)

--- a/notebooks/example.ipynb
+++ b/notebooks/example.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# AlviaOrange Example Notebook",
+    "\n",
+    "This notebook demonstrates how to use `fetch_hotspots` from the `alviaorange` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from alviaorange import fetch_hotspots\n",
+    "fetch_hotspots()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "alviaorange"
+version = "0.1.0"
+description = "Wildfire analytics and simulation tools"
+readme = "README.md"
+authors = [{ name = "AlviaOrange" }]
+requires-python = ">=3.10"
+keywords = ["wildfire", "analytics"]
+license = { file = "LICENSE" }
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://example.com"
+
+[tool.setuptools.packages.find]
+where = ["alviaorange"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra"
+testpaths = ["tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Core dependencies
+fastapi
+uvicorn
+

--- a/scripts/run_server.py
+++ b/scripts/run_server.py
@@ -1,0 +1,11 @@
+"""Start the AlviaOrange HTTP server."""
+
+from __future__ import annotations
+
+import uvicorn
+
+from alviaorange.server import app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual entry
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,12 @@
+import subprocess
+import sys
+
+
+def test_cli_default():
+    result = subprocess.run(
+        [sys.executable, '-m', 'alviaorange.cli'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert 'AB-001' in result.stdout

--- a/tests/test_hotspots.py
+++ b/tests/test_hotspots.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from alviaorange.hotspots import fetch_hotspots
+
+
+def test_fetch_hotspots_default():
+    assert fetch_hotspots() == ["AB-001", "BC-123"]


### PR DESCRIPTION
## Summary
- add project README with setup instructions
- provide MIT License and Python `.gitignore`
- implement `fetch_hotspots` example and expose via package
- add test suite and example notebook
- configure GitHub Actions to run tests
- set up `pyproject.toml` for packaging
- add CLI and HTTP server placeholders
- include region-specific modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845d47600b483248c9c26ffa96e0014