### PR TITLE
Add Canadian air quality history and scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ Invoke the command line interface to print hotspots:
 python -m alviaorange.cli --region Canada
 ```
 
+## Air Quality Retrieval
+
+The package also includes a function to fetch Canadian Air Quality data from
+Environment Canada's website. Usage example:
+
+```python
+from alviaorange import fetch_air_quality
+
+data = fetch_air_quality()
+print(data.get("Toronto"))
+```
+
+Additional helpers are available:
+
+```python
+from alviaorange import fetch_aqi_scale, fetch_air_quality_history
+
+scale = fetch_aqi_scale()
+history = fetch_air_quality_history("Toronto", "2024-01-01")
+```
+
 ## Starting the HTTP server
 
 An HTTP endpoint can be started with:

--- a/README.md
+++ b/README.md
@@ -59,13 +59,14 @@ data = fetch_air_quality()
 print(data.get("Toronto"))
 ```
 
-Additional helpers are available:
+Additional helpers are available. Historical data can be fetched for a
+specific date or a range:
 
 ```python
 from alviaorange import fetch_aqi_scale, fetch_air_quality_history
 
 scale = fetch_aqi_scale()
-history = fetch_air_quality_history("Toronto", "2024-01-01")
+history = fetch_air_quality_history("Toronto", "2024-01-01", "2024-01-02")
 ```
 
 ## Starting the HTTP server

--- a/alviaorange/__init__.py
+++ b/alviaorange/__init__.py
@@ -1,5 +1,15 @@
 """Core package for AlviaOrange wildfire analytics."""
 
 from .hotspots import fetch_hotspots
+from .air_quality import (
+    fetch_air_quality,
+    fetch_aqi_scale,
+    fetch_air_quality_history,
+)
 
-__all__ = ["fetch_hotspots"]
+__all__ = [
+    "fetch_hotspots",
+    "fetch_air_quality",
+    "fetch_aqi_scale",
+    "fetch_air_quality_history",
+]

--- a/alviaorange/air_quality.py
+++ b/alviaorange/air_quality.py
@@ -1,0 +1,85 @@
+"""Retrieve Canadian air quality data from Environment Canada."""
+
+from __future__ import annotations
+
+import requests
+from bs4 import BeautifulSoup
+from typing import Dict
+
+URL = "https://weather.gc.ca/mainmenu/airquality_menu_e.html"
+
+
+def fetch_air_quality() -> Dict[str, str]:
+    """Fetch air quality information from Environment Canada.
+
+    Returns a mapping of city names to their reported air quality index. This
+    parser is based on the HTML layout of the Air Quality menu page. If the
+    layout changes, this function may need to be updated.
+    """
+    response = requests.get(URL, timeout=10)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    data: Dict[str, str] = {}
+
+    # Example HTML structure assumption:
+    # <table id="AQHI"> <tr><td>City</td><td>Index</td></tr> ...
+    for row in soup.select("table tr"):
+        cells = [c.get_text(strip=True) for c in row.find_all("td")]
+        if len(cells) >= 2:
+            city, index = cells[0], cells[1]
+            data[city] = index
+    return data
+
+AQI_SCALE_URL = "https://weather.gc.ca/mainmenu/airquality_health_e.html"
+HISTORY_URL_TEMPLATE = (
+    "https://dd.weather.gc.ca/air_quality/aqhi/{city}/observation/{date}_aqhi.csv"
+)
+
+
+def _expand_index_range(text: str) -> list[str]:
+    """Expand a range like '1-3' into ['1', '2', '3']."""
+    text = text.strip()
+    if text.endswith("+"):
+        return [text]
+    if "-" in text:
+        start, end = text.split("-", 1)
+        return [str(i) for i in range(int(start), int(end) + 1)]
+    return [text]
+
+
+def fetch_aqi_scale() -> Dict[str, Dict[str, str]]:
+    """Return mapping of AQHI values to risk bands and messages."""
+    response = requests.get(AQI_SCALE_URL, timeout=10)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    mapping: Dict[str, Dict[str, str]] = {}
+    for row in soup.select("table tr"):
+        cells = [c.get_text(strip=True) for c in row.find_all("td")]
+        if len(cells) >= 3:
+            index_range, band, meaning = cells[0], cells[1], cells[2]
+            for val in _expand_index_range(index_range):
+                mapping[val] = {"band": band, "meaning": meaning}
+    return mapping
+
+
+def fetch_air_quality_history(city: str, date: str) -> list[dict[str, str]]:
+    """Fetch historical AQHI data for a city and date (YYYY-MM-DD)."""
+    url = HISTORY_URL_TEMPLATE.format(city=city.lower(), date=date.replace("-", ""))
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+
+    lines = [line for line in response.text.splitlines() if line and not line.startswith("#")]
+    if not lines:
+        return []
+
+    import csv
+
+    reader = csv.reader(lines)
+    header = next(reader, None)
+    history = []
+    for row in reader:
+        if len(row) >= 2:
+            history.append({"datetime": row[0], "value": row[1]})
+    return history

--- a/alviaorange/server.py
+++ b/alviaorange/server.py
@@ -33,6 +33,8 @@ def get_air_quality_scale() -> dict[str, dict[str, str]]:
 
 
 @app.get("/air_quality/history")
-def get_air_quality_history(city: str, date: str) -> list[dict[str, str]]:
-    """Return historical AQHI data for a city and date."""
-    return fetch_air_quality_history(city, date)
+def get_air_quality_history(
+    city: str, start: str, end: str | None = None
+) -> list[dict[str, str]]:
+    """Return historical AQHI data for a city within a date range."""
+    return fetch_air_quality_history(city, start, end)

--- a/alviaorange/server.py
+++ b/alviaorange/server.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from .hotspots import fetch_hotspots
+from .air_quality import (
+    fetch_air_quality,
+    fetch_aqi_scale,
+    fetch_air_quality_history,
+)
 
 app = FastAPI()
 
@@ -13,3 +18,21 @@ app = FastAPI()
 def get_hotspots(region: str = "Canada") -> list[str]:
     """Return hotspots for the specified region."""
     return fetch_hotspots(region)
+
+
+@app.get("/air_quality")
+def get_air_quality() -> dict[str, str]:
+    """Return a mapping of city names to air quality index."""
+    return fetch_air_quality()
+
+
+@app.get("/air_quality/scale")
+def get_air_quality_scale() -> dict[str, dict[str, str]]:
+    """Return the AQHI scale mapping."""
+    return fetch_aqi_scale()
+
+
+@app.get("/air_quality/history")
+def get_air_quality_history(city: str, date: str) -> list[dict[str, str]]:
+    """Return historical AQHI data for a city and date."""
+    return fetch_air_quality_history(city, date)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 # Core dependencies
 fastapi
 uvicorn
+requests
+beautifulsoup4
 

--- a/tests/test_air_quality.py
+++ b/tests/test_air_quality.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -73,13 +74,27 @@ def test_fetch_air_quality_history(monkeypatch):
 
     def fake_get(url, timeout=10):
         assert "toronto" in url
-        assert "20240101" in url
+        assert "2024010" in url  # allows 20240101 or 20240102
         return DummyResponse(csv)
 
     import alviaorange.air_quality as aq
 
     monkeypatch.setattr(aq.requests, "get", fake_get)
 
-    data = fetch_air_quality_history("Toronto", "2024-01-01")
+    data = fetch_air_quality_history("Toronto", "2024-01-01", "2024-01-02")
     assert data[0]["value"] == "3"
     assert data[1]["datetime"].endswith("01:00Z")
+
+
+def test_history_invalid_range(monkeypatch):
+    import alviaorange.air_quality as aq
+
+    csv = "Date,Value\n"
+
+    def fake_get(url, timeout=10):
+        return DummyResponse(csv)
+
+    monkeypatch.setattr(aq.requests, "get", fake_get)
+
+    with pytest.raises(ValueError):
+        fetch_air_quality_history("Toronto", "2024-01-02", "2024-01-01")

--- a/tests/test_air_quality.py
+++ b/tests/test_air_quality.py
@@ -1,0 +1,85 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from alviaorange.air_quality import (
+    fetch_air_quality,
+    fetch_aqi_scale,
+    fetch_air_quality_history,
+    URL,
+    AQI_SCALE_URL,
+    HISTORY_URL_TEMPLATE,
+)
+
+
+class DummyResponse:
+    def __init__(self, text: str):
+        self.text = text
+
+    def raise_for_status(self) -> None:  # noqa: D401 - simple no-op
+        """Mimic requests' Response.raise_for_status."""
+        return None
+
+
+def test_fetch_air_quality(monkeypatch):
+    html = """
+    <html><body>
+    <table id='aqhi'>
+        <tr><td>Toronto</td><td>5</td></tr>
+        <tr><td>Vancouver</td><td>3</td></tr>
+    </table>
+    </body></html>
+    """
+
+    def fake_get(url, timeout=10):
+        assert url == URL
+        return DummyResponse(html)
+
+    import alviaorange.air_quality as aq
+
+    monkeypatch.setattr(aq.requests, "get", fake_get)
+
+    data = fetch_air_quality()
+    assert data == {"Toronto": "5", "Vancouver": "3"}
+
+
+def test_fetch_aqi_scale(monkeypatch):
+    html = """
+    <table>
+        <tr><td>1-3</td><td>Low</td><td>Good</td></tr>
+        <tr><td>4-6</td><td>Moderate</td><td>Caution</td></tr>
+        <tr><td>7-9</td><td>High</td><td>Limit activities</td></tr>
+        <tr><td>10+</td><td>Very High</td><td>Avoid outdoors</td></tr>
+    </table>
+    """
+
+    def fake_get(url, timeout=10):
+        assert url == AQI_SCALE_URL
+        return DummyResponse(html)
+
+    import alviaorange.air_quality as aq
+
+    monkeypatch.setattr(aq.requests, "get", fake_get)
+
+    data = fetch_aqi_scale()
+    assert data["1"]["band"] == "Low"
+    assert data["5"]["band"] == "Moderate"
+    assert data["10+"]["band"] == "Very High"
+
+
+def test_fetch_air_quality_history(monkeypatch):
+    csv = """Date,Value\n2024-01-01T00:00Z,3\n2024-01-01T01:00Z,4\n"""
+
+    def fake_get(url, timeout=10):
+        assert "toronto" in url
+        assert "20240101" in url
+        return DummyResponse(csv)
+
+    import alviaorange.air_quality as aq
+
+    monkeypatch.setattr(aq.requests, "get", fake_get)
+
+    data = fetch_air_quality_history("Toronto", "2024-01-01")
+    assert data[0]["value"] == "3"
+    assert data[1]["datetime"].endswith("01:00Z")


### PR DESCRIPTION
## Summary
- fetch dynamic AQHI scale and historical index values
- expose new helpers in package and FastAPI server
- document new features in README
- test `fetch_aqi_scale` and `fetch_air_quality_history`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845dadf89b483249a595ec0104351b8