### PR TITLE
Add CWFIS data client

### DIFF
--- a/alviaorange/__init__.py
+++ b/alviaorange/__init__.py
@@ -6,10 +6,30 @@ from .air_quality import (
     fetch_aqi_scale,
     fetch_air_quality_history,
 )
+from .cwfis import (
+    fetch_fire_weather_index,
+    fetch_fire_danger,
+    fetch_fire_perimeter,
+    fetch_m3_hotspots,
+    fetch_season_hotspots,
+    fetch_active_fires,
+    fetch_forecast_weather_stations,
+    fetch_reporting_weather_stations,
+    fetch_fire_history,
+)
 
 __all__ = [
     "fetch_hotspots",
     "fetch_air_quality",
     "fetch_aqi_scale",
     "fetch_air_quality_history",
+    "fetch_fire_weather_index",
+    "fetch_fire_danger",
+    "fetch_fire_perimeter",
+    "fetch_m3_hotspots",
+    "fetch_season_hotspots",
+    "fetch_active_fires",
+    "fetch_forecast_weather_stations",
+    "fetch_reporting_weather_stations",
+    "fetch_fire_history",
 ]

--- a/alviaorange/cwfis.py
+++ b/alviaorange/cwfis.py
@@ -1,0 +1,85 @@
+"""Client for accessing CWFIS interactive map layers."""
+
+from __future__ import annotations
+
+import requests
+from typing import Any, Dict
+
+BASE_URL = "https://cwfis.cfs.nrcan.gc.ca"  # Default API base
+
+
+def fetch_layer(layer: str, **params: str) -> Dict[str, Any]:
+    """Return JSON for a given interactive map layer.
+
+    Parameters
+    ----------
+    layer:
+        Name of the desired layer, e.g. ``"fire-weather-index"``.
+    **params:
+        Additional query parameters such as ``date`` or ``region``.
+    """
+
+    query = "&".join(f"{k}={v}" for k, v in params.items() if v is not None)
+    url = f"{BASE_URL}/interactive-map/api/{layer}"
+    if query:
+        url = f"{url}?{query}"
+
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+# Convenience wrappers for common layers
+
+def fetch_fire_weather_index(date: str, region: str | None = None) -> Dict[str, Any]:
+    """Fetch Fire Weather Index values for a specific date."""
+
+    return fetch_layer("fire-weather-index", date=date, region=region)
+
+
+def fetch_fire_danger(date: str, region: str | None = None) -> Dict[str, Any]:
+    """Fetch Fire Danger ratings for a specific date."""
+
+    return fetch_layer("fire-danger", date=date, region=region)
+
+
+def fetch_fire_perimeter(date: str) -> Dict[str, Any]:
+    """Fetch Fire Perimeter estimate for a given date."""
+
+    return fetch_layer("fire-perimeter", date=date)
+
+
+def fetch_m3_hotspots(date: str) -> Dict[str, Any]:
+    """Fetch M3 Hotspot data for a date."""
+
+    return fetch_layer("m3-hotspots", date=date)
+
+
+def fetch_season_hotspots(year: int) -> Dict[str, Any]:
+    """Fetch season-to-date hotspots for a year."""
+
+    return fetch_layer("season-hotspots", year=str(year))
+
+
+def fetch_active_fires() -> Dict[str, Any]:
+    """Fetch data for currently active fires."""
+
+    return fetch_layer("active-fires")
+
+
+def fetch_forecast_weather_stations() -> Dict[str, Any]:
+    """Fetch forecast weather station information."""
+
+    return fetch_layer("forecast-weather-stations")
+
+
+def fetch_reporting_weather_stations() -> Dict[str, Any]:
+    """Fetch reporting weather station information."""
+
+    return fetch_layer("reporting-weather-stations")
+
+
+def fetch_fire_history(region: str, start: str, end: str) -> Dict[str, Any]:
+    """Fetch fire history records for a region within a date range."""
+
+    return fetch_layer("fire-history", region=region, start=start, end=end)

--- a/alviaorange/server.py
+++ b/alviaorange/server.py
@@ -10,6 +10,17 @@ from .air_quality import (
     fetch_aqi_scale,
     fetch_air_quality_history,
 )
+from .cwfis import (
+    fetch_fire_weather_index,
+    fetch_fire_danger,
+    fetch_fire_perimeter,
+    fetch_m3_hotspots,
+    fetch_season_hotspots,
+    fetch_active_fires,
+    fetch_forecast_weather_stations,
+    fetch_reporting_weather_stations,
+    fetch_fire_history,
+)
 
 app = FastAPI()
 
@@ -38,3 +49,66 @@ def get_air_quality_history(
 ) -> list[dict[str, str]]:
     """Return historical AQHI data for a city within a date range."""
     return fetch_air_quality_history(city, start, end)
+
+
+@app.get("/cwfis/fwi")
+def get_fire_weather_index(date: str, region: str | None = None) -> dict[str, any]:
+    """Return Fire Weather Index for a date."""
+
+    return fetch_fire_weather_index(date, region)
+
+
+@app.get("/cwfis/fire_danger")
+def get_fire_danger(date: str, region: str | None = None) -> dict[str, any]:
+    """Return Fire Danger ratings."""
+
+    return fetch_fire_danger(date, region)
+
+
+@app.get("/cwfis/fire_perimeter")
+def get_fire_perimeter(date: str) -> dict[str, any]:
+    """Return estimated fire perimeters."""
+
+    return fetch_fire_perimeter(date)
+
+
+@app.get("/cwfis/m3_hotspots")
+def get_m3_hotspots(date: str) -> dict[str, any]:
+    """Return M3 hotspot information."""
+
+    return fetch_m3_hotspots(date)
+
+
+@app.get("/cwfis/season_hotspots")
+def get_season_hotspots(year: int) -> dict[str, any]:
+    """Return season-to-date hotspots for a year."""
+
+    return fetch_season_hotspots(year)
+
+
+@app.get("/cwfis/active_fires")
+def get_active_fires() -> dict[str, any]:
+    """Return currently active fires."""
+
+    return fetch_active_fires()
+
+
+@app.get("/cwfis/forecast_stations")
+def get_forecast_weather_stations() -> dict[str, any]:
+    """Return forecast weather station data."""
+
+    return fetch_forecast_weather_stations()
+
+
+@app.get("/cwfis/reporting_stations")
+def get_reporting_weather_stations() -> dict[str, any]:
+    """Return reporting weather station data."""
+
+    return fetch_reporting_weather_stations()
+
+
+@app.get("/cwfis/history")
+def get_fire_history(region: str, start: str, end: str) -> dict[str, any]:
+    """Return fire history for a region within a date range."""
+
+    return fetch_fire_history(region, start, end)

--- a/tests/test_cwfis.py
+++ b/tests/test_cwfis.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import alviaorange.cwfis as cw
+from alviaorange.cwfis import (
+    fetch_fire_weather_index,
+    fetch_fire_danger,
+    fetch_fire_perimeter,
+    fetch_m3_hotspots,
+    fetch_season_hotspots,
+    fetch_active_fires,
+    fetch_forecast_weather_stations,
+    fetch_reporting_weather_stations,
+    fetch_fire_history,
+    BASE_URL,
+)
+
+
+class DummyResponse:
+    def __init__(self, text: str):
+        self.text = text
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        import json
+        return json.loads(self.text)
+
+
+def fake_get_factory(expected_url):
+    def fake_get(url, timeout=10):
+        assert url == expected_url
+        return DummyResponse('{"result": "ok"}')
+    return fake_get
+
+
+def test_fetch_fire_weather_index(monkeypatch):
+    url = f"{BASE_URL}/interactive-map/api/fire-weather-index?date=2024-01-01&region=ON"
+    monkeypatch.setattr(cw.requests, "get", fake_get_factory(url))
+    data = fetch_fire_weather_index("2024-01-01", region="ON")
+    assert data["result"] == "ok"
+
+
+def test_fetch_active_fires(monkeypatch):
+    url = f"{BASE_URL}/interactive-map/api/active-fires"
+    monkeypatch.setattr(cw.requests, "get", fake_get_factory(url))
+    data = fetch_active_fires()
+    assert data["result"] == "ok"


### PR DESCRIPTION
## Summary
- add CWFIS API client with helpers for common layers
- expose new endpoints in the FastAPI server
- export new utilities in `__init__`
- add unit tests for CWFIS client

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845e13fc2bc8324be57a732f2343c1c