### PR TITLE
Add shapefile region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ Invoke the command line interface to print hotspots:
 python -m alviaorange.cli --region Canada
 ```
 
+Shapefiles can also be supplied instead of a region name. When the provided
+polygon spans multiple supported regions, hotspots for each region will be
+printed with the region name prefix.
+
+If the shapefile includes a `.prj` file, its geometry will be reprojected to
+WGS84 so that the coordinates match the simple polygons used in this example.
+Otherwise the coordinates are assumed to already be in longitude/latitude.
+
+```bash
+python -m alviaorange.cli --region path/to/area.shp
+```
+
 ## Air Quality Retrieval
 
 The package also includes a function to fetch Canadian Air Quality data from

--- a/alviaorange/cli.py
+++ b/alviaorange/cli.py
@@ -17,8 +17,13 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
     hotspots = fetch_hotspots(args.region)
-    for hotspot in hotspots:
-        print(hotspot)
+    if isinstance(hotspots, dict):
+        for region, hs in hotspots.items():
+            for hotspot in hs:
+                print(f"{region}: {hotspot}")
+    else:
+        for hotspot in hotspots:
+            print(hotspot)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry

--- a/alviaorange/hotspots.py
+++ b/alviaorange/hotspots.py
@@ -1,17 +1,76 @@
-"""Example hotspot retrieval module."""
+"""Hotspot retrieval utilities with basic region and shapefile support."""
 
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List, Union
+
+from pathlib import Path
+
+import shapefile  # type: ignore
+from shapely.geometry import Polygon, shape
+from shapely.ops import unary_union, transform
+from pyproj import CRS, Transformer
 
 
-def fetch_hotspots(region: str = "Canada") -> List[str]:
-    """Return a list of hotspot identifiers for a given region.
+# Simplistic polygon definitions for Canada and the USA. These are rough
+# bounding boxes purely for demonstration purposes.
+_CANADA_POLYGON = Polygon([(-141, 41), (-52, 41), (-52, 83), (-141, 83)])
+_USA_POLYGON = Polygon([(-125, 24), (-66, 24), (-66, 49), (-125, 49)])
 
-    This is a placeholder implementation that returns sample data.
-    """
+# Mapping of region name to polygon
+REGION_SHAPES: Dict[str, Polygon] = {
+    "Canada": _CANADA_POLYGON,
+    "USA": _USA_POLYGON,
+}
+
+
+def _read_shapefile(path: Path) -> Polygon:
+    """Return the union of all geometries in a shapefile in WGS84 coordinates."""
+
+    reader = shapefile.Reader(str(path))
+    geometries = [shape(s.__geo_interface__) for s in reader.shapes()]
+    geom = unary_union(geometries)
+
+    prj_file = path.with_suffix(".prj")
+    if prj_file.exists():
+        prj_txt = prj_file.read_text().strip()
+        if prj_txt:
+            try:
+                src_crs = CRS.from_wkt(prj_txt)
+            except Exception:
+                try:
+                    src_crs = CRS.from_user_input(prj_txt)
+                except Exception:
+                    src_crs = None
+            if src_crs and src_crs != CRS.from_epsg(4326):
+                transformer = Transformer.from_crs(src_crs, 4326, always_xy=True)
+                geom = transform(transformer.transform, geom)
+
+    return geom
+
+
+def _fetch_by_region_name(name: str) -> List[str]:
+    """Internal helper returning hotspot list for a named region."""
+
     sample_data = {
         "Canada": ["AB-001", "BC-123"],
         "USA": ["CA-999", "OR-456"],
     }
-    return sample_data.get(region, [])
+    return sample_data.get(name, [])
+
+
+def fetch_hotspots(
+    region: Union[str, Path] = "Canada",
+) -> Union[List[str], Dict[str, List[str]]]:
+    """Return hotspot identifiers for a region or regions defined by a shapefile."""
+
+    path = Path(region)
+    if path.exists() and path.suffix.lower() == ".shp":
+        geom = _read_shapefile(path)
+        results: Dict[str, List[str]] = {}
+        for name, poly in REGION_SHAPES.items():
+            if poly.intersects(geom):
+                results[name] = _fetch_by_region_name(name)
+        return results
+
+    return _fetch_by_region_name(str(region))

--- a/alviaorange/server.py
+++ b/alviaorange/server.py
@@ -26,8 +26,8 @@ app = FastAPI()
 
 
 @app.get("/hotspots")
-def get_hotspots(region: str = "Canada") -> list[str]:
-    """Return hotspots for the specified region."""
+def get_hotspots(region: str = "Canada") -> list[str] | dict[str, list[str]]:
+    """Return hotspots for the specified region or shapefile."""
     return fetch_hotspots(region)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,7 @@ fastapi
 uvicorn
 requests
 beautifulsoup4
+shapely
+pyshp
+pyproj
 

--- a/tests/test_hotspots.py
+++ b/tests/test_hotspots.py
@@ -10,3 +10,56 @@ from alviaorange.hotspots import fetch_hotspots
 
 def test_fetch_hotspots_default():
     assert fetch_hotspots() == ["AB-001", "BC-123"]
+
+
+def test_fetch_hotspots_shapefile(tmp_path):
+    import shapefile
+
+    shp_path = tmp_path / "area"
+    w = shapefile.Writer(str(shp_path))
+    w.field("name", "C")
+    # Polygon that spans southern Canada and northern USA
+    w.poly(
+        [
+            [
+                (-110, 45),
+                (-90, 45),
+                (-90, 55),
+                (-110, 55),
+                (-110, 45),
+            ]
+        ]
+    )
+    w.record("test")
+    w.close()
+
+    result = fetch_hotspots(shp_path.with_suffix(".shp"))
+    assert isinstance(result, dict)
+    assert "Canada" in result
+    assert "USA" in result
+
+
+def test_fetch_hotspots_shapefile_projected(tmp_path):
+    import shapefile
+    import pyproj
+
+    shp_path = tmp_path / "area"
+    w = shapefile.Writer(str(shp_path))
+    w.field("name", "C")
+    transformer = pyproj.Transformer.from_crs(4326, 3857, always_xy=True)
+    ring = [
+        (-110, 45),
+        (-90, 45),
+        (-90, 55),
+        (-110, 55),
+        (-110, 45),
+    ]
+    w.poly([[transformer.transform(x, y) for x, y in ring]])
+    w.record("test")
+    w.close()
+    (tmp_path / "area.prj").write_text(pyproj.CRS.from_epsg(3857).to_wkt())
+
+    result = fetch_hotspots(shp_path.with_suffix(".shp"))
+    assert isinstance(result, dict)
+    assert "Canada" in result
+    assert "USA" in result


### PR DESCRIPTION
## Summary
- enable shapefile support in `fetch_hotspots`
- handle shapefiles in CLI and server
- document shapefile usage in README
- add shapely and pyshp requirements
- test shapefile handling
- **handle shapefile projections**

## Testing
- `pip install -r requirements.txt --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e3fe15cc832486ec5380116d7ea7