### PR TITLE
Implement WMS tile URL helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,32 @@ be found in the `notebooks/` directory. There is one notebook for each public
 function so you can run them individually and explore the outputs
 interactively.
 
+### Displaying Fire Danger WMS tiles
+
+The `fire_danger_wms_tile_url(date)` helper returns a WMS tile URL for the
+Canadian Wildland Fire Information System (CWFIS). It can be used to display the
+Fire Danger Rating layer on interactive maps. The example notebooks demonstrate
+this with Plotly:
+
+```python
+from alviaorange import fire_danger_wms_tile_url
+import plotly.graph_objects as go
+
+token = "YOUR_MAPBOX_ACCESS_TOKEN"
+tile_url = fire_danger_wms_tile_url("20230401")
+
+fig = go.Figure(go.Scattermapbox())
+fig.update_layout(
+    mapbox=dict(
+        accesstoken=token,
+        style="open-street-map",
+        layers=[dict(sourcetype="raster", source=[tile_url], below="traces")],
+    ),
+    margin={"r": 0, "t": 0, "l": 0, "b": 0},
+)
+fig.show()
+```
+
 ## Node.js/TypeScript integration
 
 Developers can interface with the Python tools using a CLI script or by exposing an

--- a/alviaorange/__init__.py
+++ b/alviaorange/__init__.py
@@ -1,28 +1,20 @@
-"""Core package for AlviaOrange wildfire analytics."""
+"""Core package for AlviaOrange wildfire analytics.
 
-from .hotspots import fetch_hotspots
-from .air_quality import (
-    fetch_air_quality,
-    fetch_aqi_scale,
-    fetch_air_quality_history,
-)
-from .cwfis import (
-    fetch_fire_weather_index,
-    fetch_fire_danger,
-    fetch_fire_perimeter,
-    fetch_m3_hotspots,
-    fetch_season_hotspots,
-    fetch_active_fires,
-    fetch_forecast_weather_stations,
-    fetch_reporting_weather_stations,
-    fetch_fire_history,
-)
+The top level package lazily exposes helpers from the various submodules so that
+optional heavy dependencies are only imported when the corresponding function is
+first accessed.  This avoids ``ImportError`` issues for users that only need a
+subset of the functionality.
+"""
 
-__all__ = [
-    "fetch_hotspots",
+from importlib import import_module
+
+_AIR_QUALITY_FUNCS = {
     "fetch_air_quality",
     "fetch_aqi_scale",
     "fetch_air_quality_history",
+}
+
+_CWFIS_FUNCS = {
     "fetch_fire_weather_index",
     "fetch_fire_danger",
     "fetch_fire_perimeter",
@@ -32,4 +24,24 @@ __all__ = [
     "fetch_forecast_weather_stations",
     "fetch_reporting_weather_stations",
     "fetch_fire_history",
-]
+    "fire_danger_wms_tile_url",
+}
+
+_HOTSPOT_FUNCS = {"fetch_hotspots"}
+
+__all__ = sorted(_AIR_QUALITY_FUNCS | _CWFIS_FUNCS | _HOTSPOT_FUNCS)
+
+
+def __getattr__(name: str):
+    """Dynamically import and return the requested helper."""
+
+    if name in _HOTSPOT_FUNCS:
+        module = import_module(".hotspots", __name__)
+        return getattr(module, name)
+    if name in _AIR_QUALITY_FUNCS:
+        module = import_module(".air_quality", __name__)
+        return getattr(module, name)
+    if name in _CWFIS_FUNCS:
+        module = import_module(".cwfis", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/alviaorange/cwfis.py
+++ b/alviaorange/cwfis.py
@@ -83,3 +83,24 @@ def fetch_fire_history(region: str, start: str, end: str) -> Dict[str, Any]:
     """Fetch fire history records for a region within a date range."""
 
     return fetch_layer("fire-history", region=region, start=start, end=end)
+
+
+def fire_danger_wms_tile_url(date: str | int) -> str:
+    """Return WMS tile URL template for Fire Danger Ratings.
+
+    Parameters
+    ----------
+    date:
+        Date in ``YYYYMMDD`` format used by the WMS layer names.
+    """
+
+    date_str = str(date)
+    return (
+        "https://cwfis.cfs.nrcan.gc.ca/geoserver/public/wms?"
+        "service=WMS&version=1.1.1&request=GetMap&"
+        f"layers=public:fdr{date_str}&"
+        "styles=cffdrs_fdr_opaque&"
+        "format=image/png&transparent=true&"
+        "srs=EPSG:3857&bbox={bbox-epsg-3857}&"
+        "width=256&height=256"
+    )

--- a/alviaorange/server.py
+++ b/alviaorange/server.py
@@ -20,6 +20,7 @@ from .cwfis import (
     fetch_forecast_weather_stations,
     fetch_reporting_weather_stations,
     fetch_fire_history,
+    fire_danger_wms_tile_url,
 )
 
 app = FastAPI()
@@ -63,6 +64,13 @@ def get_fire_danger(date: str, region: str | None = None) -> dict[str, any]:
     """Return Fire Danger ratings."""
 
     return fetch_fire_danger(date, region)
+
+
+@app.get("/cwfis/fire_danger_tile")
+def get_fire_danger_tile(date: str) -> str:
+    """Return WMS tile URL template for Fire Danger Ratings."""
+
+    return fire_danger_wms_tile_url(date)
 
 
 @app.get("/cwfis/fire_perimeter")

--- a/notebooks/cwfis.ipynb
+++ b/notebooks/cwfis.ipynb
@@ -45,13 +45,23 @@
     }
    ],
    "source": [
-    "from alviaorange import fetch_fire_weather_index\n",
-    "import plotly.express as px\n",
+    "from alviaorange import fire_danger_wms_tile_url\n",
+    "import plotly.graph_objects as go\n",
     "\n",
-    "data = fetch_fire_weather_index('2024-01-01')\n",
-    "features = data.get('features', [])\n",
-    "values = [f['properties'].get('FWI') for f in features if 'properties' in f] \n",
-    "fig = px.histogram(values, nbins=20, title='Fire Weather Index distribution')\n",
+    "mapbox_access_token = 'YOUR_MAPBOX_ACCESS_TOKEN'\n",
+    "url = fire_danger_wms_tile_url('20230401')\n",
+    "\n",
+    "fig = go.Figure(go.Scattermapbox())\n",
+    "fig.update_layout(\n",
+    "    mapbox=dict(\n",
+    "        accesstoken=mapbox_access_token,\n",
+    "        style='open-street-map',\n",
+    "        center=dict(lat=50, lon=-95),\n",
+    "        zoom=3,\n",
+    "        layers=[dict(sourcetype='raster', source=[url], below='traces', opacity=0.7)]\n",
+    "    ),\n",
+    "    margin={'r':0,'t':0,'l':0,'b':0}\n",
+    ")\n",
     "fig.show()"
    ]
   }

--- a/notebooks/fetch_fire_danger.ipynb
+++ b/notebooks/fetch_fire_danger.ipynb
@@ -45,14 +45,23 @@
     }
    ],
    "source": [
-    "from alviaorange import fetch_fire_danger\n",
-    "import plotly.express as px\n",
+    "from alviaorange import fire_danger_wms_tile_url\n",
+    "import plotly.graph_objects as go\n",
     "\n",
-    "data = fetch_fire_danger('2024-01-01')\n",
-    "features = data.get('features', []) if isinstance(data, dict) else data\n",
-    "fig = px.bar(x=['count'], y=[len(features)],\n",
-    "             labels={'x': 'Dataset', 'y': 'Count'},\n",
-    "             title='Fire Danger Ratings')\n",
+    "token = 'YOUR_MAPBOX_ACCESS_TOKEN'\n",
+    "tile = fire_danger_wms_tile_url('20230401')\n",
+    "\n",
+    "fig = go.Figure(go.Scattermapbox())\n",
+    "fig.update_layout(\n",
+    "    mapbox=dict(\n",
+    "        accesstoken=token,\n",
+    "        style='open-street-map',\n",
+    "        center=dict(lat=50, lon=-95),\n",
+    "        zoom=3,\n",
+    "        layers=[dict(sourcetype='raster', source=[tile], below='traces', opacity=0.7)]\n",
+    "    ),\n",
+    "    margin={'r':0,'t':0,'l':0,'b':0}\n",
+    ")\n",
     "fig.show()"
    ]
   }

--- a/tests/test_cwfis.py
+++ b/tests/test_cwfis.py
@@ -15,6 +15,7 @@ from alviaorange.cwfis import (
     fetch_forecast_weather_stations,
     fetch_reporting_weather_stations,
     fetch_fire_history,
+    fire_danger_wms_tile_url,
     BASE_URL,
 )
 
@@ -50,3 +51,10 @@ def test_fetch_active_fires(monkeypatch):
     monkeypatch.setattr(cw.requests, "get", fake_get_factory(url))
     data = fetch_active_fires()
     assert data["result"] == "ok"
+
+
+def test_fire_danger_wms_tile_url():
+    url = fire_danger_wms_tile_url("20230401")
+    assert "layers=public:fdr20230401" in url
+    assert url.startswith("https://cwfis.cfs.nrcan.gc.ca/geoserver/public/wms?")
+    assert "{bbox-epsg-3857}" in url


### PR DESCRIPTION
## Summary
- add `fire_danger_wms_tile_url` helper
- expose new helper from package and server
- update example notebooks to use the tile URL helper
- test helper in `test_cwfis`
- lazy-load submodules so optional dependencies aren't required on import
- document using the tile URL in README

## Testing
- `pytest -q`
- `jupyter nbconvert --to notebook --execute notebooks/cwfis.ipynb`
- `jupyter nbconvert --to notebook --execute notebooks/fetch_fire_danger.ipynb`


------
https://chatgpt.com/codex/tasks/task_e_6845f0ca889c8324b8a7c0d82766b44a